### PR TITLE
Fixed an issue with the parameter list when there are multiple actions

### DIFF
--- a/Content/VisualPDDL/js/vppdl_block_defs.js
+++ b/Content/VisualPDDL/js/vppdl_block_defs.js
@@ -99,9 +99,11 @@ Blockly.Blocks['action'] = {
       var childParamBlocks = this.getDescendants();
       this.parameters_ = [];
       if (childParamBlocks != null) {
-        for (let i in childParamBlocks) {
+        for (var i = 0; i < childParamBlocks.length; i++) {
           if (childParamBlocks[i].type == 'parameter')
             this.parameters_.push([childParamBlocks[i].getFieldValue('NAME'), childParamBlocks[i].getFieldValue('type')]);
+          if (i > 0 && childParamBlocks[i].type == 'action') // encountered next action, do not read its parameters
+            break;
         }
       }
     }


### PR DESCRIPTION
Fixed the issue where the parameter list in a drop down would populate with parameters in this action block and all action blocks below it.
![image](https://user-images.githubusercontent.com/19826774/127380193-d9bfc487-0fb8-419c-836b-fb77403c1b90.png)
